### PR TITLE
Tweak condition for cooldown.exclude

### DIFF
--- a/recipes/dependabot.rb
+++ b/recipes/dependabot.rb
@@ -31,7 +31,7 @@ update_file ".github/dependabot.yml" do |content|
           default-days: 7
     YAML
 
-    if content =~ /^  - package-ecosystem: bundler$/
+    if File.exist?("Gemfile")
       # Append to cooldown.exclude
       yaml << indent(<<~YAML, 6)
         exclude:


### PR DESCRIPTION
If Gemfile exists in repo, this shall be deemed as Ruby repo.